### PR TITLE
Fix SpotifySync Settings crash on malformed Spotify playlists

### DIFF
--- a/plugins/SpotifySync/src/spotifyApi.ts
+++ b/plugins/SpotifySync/src/spotifyApi.ts
@@ -129,7 +129,21 @@ export async function getMe(signal?: AbortSignal): Promise<{ id: string; display
 export async function getPlaylists(signal?: AbortSignal): Promise<SpotifyPlaylist[]> {
 	return fetchAllPages<SpotifyPlaylist>(
 		`${BASE}/me/playlists?limit=50`,
-		(data) => data.items as SpotifyPlaylist[],
+		// Spotify's /me/playlists returns null entries and items missing `tracks`/`owner`
+		// (deleted or unavailable followed playlists). Drop the unusable ones and normalize
+		// the rest so downstream render/sync can rely on the shape.
+		(data) => {
+			const items = (data.items ?? []) as (Partial<SpotifyPlaylist> | null)[];
+			return items
+				.filter((p): p is Partial<SpotifyPlaylist> => p != null && typeof p.id === "string")
+				.map((p) => ({
+					id: p.id!,
+					name: p.name ?? "(untitled)",
+					description: p.description ?? "",
+					tracks: { total: p.tracks?.total ?? 0 },
+					owner: { id: p.owner?.id ?? "" },
+				}));
+		},
 		undefined,
 		signal,
 	);


### PR DESCRIPTION
# Description
Connecting a Spotify account crashed the SpotifySync settings screen with "Settings crashed: Cannot read properties of undefined (reading 'total')", right after it showed "Connected as".

Spotify's `/me/playlists` does not always return clean data. For deleted or unavailable followed playlists it hands back `null` entries, or playlist objects missing the `tracks` and `owner` fields. The settings list assumed every playlist had them and read `p.tracks.total` while rendering, so a single bad entry in the account took the whole screen down. Two users hit this deterministically because their libraries each contain such a playlist.

# Changes
- Sanitize the Spotify playlist list at the fetch boundary in `getPlaylists`: drop `null` and id-less entries, and fill missing `tracks`, `owner`, and `name` with safe defaults.
- Downstream consumers (settings render and sync) now get a guaranteed shape, so the UI needs no per-field null checks. Sync already only reads `id` and `name`, both of which stay guaranteed.

# How to test
Manual: connect a Spotify account whose library includes a followed playlist that has been deleted or made unavailable, open SpotifySync settings, and confirm the playlist list renders instead of crashing. The normalization was checked against the exact malformed shapes (null entry, missing `tracks`, missing `owner`) and returns a render-safe list where `tracks.total` and `owner.id` are always present.

# Related issues
Fixes #2
