### PR TITLE
Allow esbuild build script so pnpm install passes in CI

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,7 @@
 packages:
  - "plugins/*"
+
+# esbuild ships a native binary via a postinstall script. pnpm 10+ blocks build
+# scripts unless allow-listed, so CI (pnpm install) hard-fails without this.
+allowBuilds:
+  esbuild: true


### PR DESCRIPTION
# Description
CI started failing at the `pnpm install` step with `[ERR_PNPM_IGNORED_BUILDS] Ignored build scripts: esbuild@0.27.3`. The workflow installs pnpm via `pnpm/action-setup@v4` with `version: latest`, which now resolves to pnpm 11. pnpm 10+ refuses to run a dependency's install script unless it is explicitly allow-listed, and in CI it exits non-zero instead of only warning. esbuild fetches its native binary in a postinstall script, so the install fails and the build step never runs.

This is pnpm version drift, not a code change. The last green run used an older pnpm that only warned about the ignored script.

# Changes
- Allow-list esbuild's build script in `pnpm-workspace.yaml` via `allowBuilds: { esbuild: true }`. This is where pnpm 11 reads the setting. The older `pnpm.onlyBuiltDependencies` field in package.json is ignored by pnpm 11 (it prints a warning and still fails).

# How to test
Verified locally with pnpm 11.9.0, matching the CI steps: a fresh `pnpm install --frozen-lockfile` followed by `pnpm run build` both succeed, `dist/` is produced with all 7 plugins, and the esbuild native binary is built. No lockfile drift.
