### PR TITLE
Update SpotifySync for Spotify's 2026 playlist API migration

### DIFF
--- a/plugins/SpotifySync/src/spotifyApi.ts
+++ b/plugins/SpotifySync/src/spotifyApi.ts
@@ -84,7 +84,7 @@ async function spotifyFetch(url: string, signal?: AbortSignal, maxRetries = 5): 
 			if (signal?.aborted) throw new DOMException("Cancelled", "AbortError");
 			continue;
 		}
-		if (res.status === 403) throw new Error("Spotify API error: 403 Forbidden. A Spotify Premium account is required. If you have Premium, try disconnecting and re-logging in to refresh permissions.");
+		if (res.status === 403) throw new Error("Spotify API error: 403 Forbidden. In Development Mode, Spotify only lets an app read playlists you own or collaborate on (not followed or editorial playlists), and requires Premium. If you own this playlist and have Premium, try disconnecting and re-logging in to refresh permissions.");
 		if (!res.ok) throw new Error(`Spotify API error: ${res.status} ${res.statusText}`);
 		return res;
 	}
@@ -132,15 +132,17 @@ export async function getPlaylists(signal?: AbortSignal): Promise<SpotifyPlaylis
 		// Spotify's /me/playlists returns null entries and items missing `tracks`/`owner`
 		// (deleted or unavailable followed playlists). Drop the unusable ones and normalize
 		// the rest so downstream render/sync can rely on the shape.
+		// The Feb/Mar 2026 API migration renamed the playlist `tracks` field to `items`,
+		// so read whichever is present or the count shows 0 for every playlist.
 		(data) => {
-			const items = (data.items ?? []) as (Partial<SpotifyPlaylist> | null)[];
+			const items = (data.items ?? []) as ((Partial<SpotifyPlaylist> & { items?: { total?: number } }) | null)[];
 			return items
-				.filter((p): p is Partial<SpotifyPlaylist> => p != null && typeof p.id === "string")
+				.filter((p): p is Partial<SpotifyPlaylist> & { items?: { total?: number } } => p != null && typeof p.id === "string")
 				.map((p) => ({
 					id: p.id!,
 					name: p.name ?? "(untitled)",
 					description: p.description ?? "",
-					tracks: { total: p.tracks?.total ?? 0 },
+					tracks: { total: p.tracks?.total ?? p.items?.total ?? 0 },
 					owner: { id: p.owner?.id ?? "" },
 				}));
 		},
@@ -154,12 +156,16 @@ export async function getPlaylistTracks(
 	onProgress?: (loaded: number, total: number) => void,
 	signal?: AbortSignal,
 ): Promise<SpotifyTrack[]> {
-	const fields = "next,total,limit,items(track(name,album(name,artists),artists,track_number,duration_ms,id,external_ids(isrc),type))";
+	// Spotify's Feb/Mar 2026 migration replaced GET /playlists/{id}/tracks (now 403 for
+	// Development Mode apps) with /items, and renamed each entry's `track` field to `item`.
+	// No `fields` projection: the old one named `track`, and the default response already
+	// carries everything we read (id, name, artists, album, external_ids.isrc, type).
+	// Read `item ?? track` so it works whichever field name the account's API version uses.
 	const tracks = await fetchAllPages<SpotifyTrack>(
-		`${BASE}/playlists/${playlistId}/tracks?limit=100&fields=${encodeURIComponent(fields)}`,
+		`${BASE}/playlists/${playlistId}/items?limit=100`,
 		(data) => {
-			const items = data.items as { track: SpotifyTrack | null }[];
-			return items.map((i) => i.track).filter((t): t is SpotifyTrack => t !== null);
+			const items = (data.items ?? []) as { item?: SpotifyTrack | null; track?: SpotifyTrack | null }[];
+			return items.map((i) => i.item ?? i.track).filter((t): t is SpotifyTrack => t != null);
 		},
 		onProgress,
 		signal,


### PR DESCRIPTION
# Description
Two Premium users on Windows reported that after connecting Spotify, every playlist shows "0 tracks" and syncing a playlist fails with "403 Forbidden. A Spotify Premium account is required." They are Premium and re-logged in, so that message was a red herring.

Both symptoms trace to one cause: Spotify's February/March 2026 Web API migration, which applies to Development Mode apps (every user of this plugin creates their own Development Mode app). The migration:

- Removed `GET /playlists/{id}/tracks`. It now returns 403. The replacement is `GET /playlists/{id}/items`.
- Renamed the playlist `tracks` field to `items`, and each track entry's `track` field to `item`.

The plugin's playlist-track fetch hit the removed endpoint, so every sync got a 403. The settings list read `tracks.total`, which no longer exists, so the earlier crash fix fell back to a count of 0.

The fix reads both the old and new field names rather than betting on one, since I can't run the live Spotify API from here.

# Changes
- Fetch playlist tracks from `/playlists/{id}/items` instead of the removed `/tracks` endpoint, and read each entry as `item ?? track`.
- Dropped the `fields` projection on that request. The old one named the removed `track` field, and the default response already includes everything the sync reads (id, name, artists, album, ISRC, type).
- Read the playlist track count from either `tracks.total` or `items.total`, so the settings list stops showing "0 tracks" for every playlist.
- Rewrote the 403 error text. It no longer claims Premium alone is the fix. It explains that Development Mode apps can only read playlists you own or collaborate on.

# Known limitation
Per Spotify's migration guide, the items endpoint only returns playlists the user owns or collaborates on. Followed and editorial playlists (like the "Bossa Chillout Covers" playlist in the issue screenshot) will still 403. That is a Spotify policy change, not something the plugin can work around. Owned playlists sync again, and the new error message tells users which case they are in.

# How to test
I verified the build and type-check pass, and added a self-check that runs the track extractor and the count normalization against both the old (`track` / `tracks.total`) and new (`item` / `items.total`) response shapes. I could not run the live Spotify API, which needs Tidal desktop, TidaLuna, and a Spotify Development Mode app. Manual check: connect Spotify, confirm owned playlists show real track counts, and sync an owned playlist.

# Related issues
Fixes #5
